### PR TITLE
Allow filtering client errors and providing context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,11 +55,17 @@ internals.handler = function (options) {
 
         var response = request.response;
 
-        if (options.wrap && response.output && response.output.statusCode >= 400) {
-            return options.wrap(response, internals.track(client, reply));
+        if (options.wrap && response.output) {
+
+            var clientErrors = options.track.clientErrors;
+            if (clientErrors || response.output.statusCode >= 500) {
+
+                var done = internals.track(client, reply);
+                return options.wrap(response, done);
+            }
         }
 
-        return reply();
+        return reply(request.response);
     };
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,5 +85,5 @@ exports.register = function (plugin, options, next) {
 
 exports.register.attributes = {
     name: 'hapi-error-wrapper',
-    version: '1.0.0'
+    version: '1.1.0'
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,18 @@
 'use strict';
 
-var Boom = require('boom');
+var url = require('url');
 var airbrake = require('airbrake');
 
 var internals = {};
+
+internals.addContext = function (request, err) {
+
+    err.url = url.format(request.url);
+    err.params = request.params;
+    err.session = request.session;
+
+    return err;
+};
 
 internals.filter = function (hidden) {
 
@@ -19,18 +28,17 @@ internals.filter = function (hidden) {
     };
 };
 
-internals.track = function (client, reply) {
+internals.track = function (request, client, reply) {
 
     return function (err, data) {
 
-        if (err) {
-            client && client.notify(err);
-            return reply(err);
-        }
+        err || (err = data);
 
-        if (data) {
-            client && client.notify(data);
-            return reply(data);
+        if (err) {
+            var verbose = internals.addContext(request, err);
+            client && client.notify(verbose);
+
+            return reply(err);
         }
 
         return reply();
@@ -60,7 +68,7 @@ internals.handler = function (options) {
             var clientErrors = options.track.clientErrors;
             if (clientErrors || response.output.statusCode >= 500) {
 
-                var done = internals.track(client, reply);
+                var done = internals.track(request, client, reply);
                 return options.wrap(response, done);
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-error-wrapper",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Hapi.js plugin to wrap and track application errors.",
   "main": "index.js",
   "directories": {

--- a/test/exclude.js
+++ b/test/exclude.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// This variable is required to mock the airbrake server
+process.env.AIRBRAKE_SERVER = 'airbrake.host.com';
+
+// Sample variables to test cgi-data filtering
+process.env.VAR_1 = 1;
+process.env.VAR_2 = 2;
+process.env.VAR_3 = 3;
+
+var Lab = require('lab');
+var Code = require('code');
+var Hapi = require('hapi');
+var Boom = require('boom');
+
+var libxmljs = require('libxmljs');
+
+var nock = require('nock');
+
+var ValidationError = require('mongoose/lib/error').ValidationError;
+
+var plugin = require('../');
+
+var lab = exports.lab = Lab.script();
+
+lab.experiment('The server extension, ignoring client issues', function () {
+
+    var server, config;
+
+    lab.before(function (done) {
+
+        config = {
+            airbrake: {
+                host: 'http://airbrake.host.com',
+                key: 'airbrake_key',
+                hidden: ['VAR_1', 'VAR_2']
+            }
+        };
+
+        server = new Hapi.Server();
+        server.connection();
+
+        server.route({
+            path: '/validation',
+            method: 'GET',
+            handler: function (request, reply) {
+                return reply(new ValidationError({}));
+            }
+        });
+
+        server.route({
+            path: '/native',
+            method: 'GET',
+            handler: function (request, reply) {
+                return reply(Boom.resourceGone());
+            }
+        });
+
+        server.route({
+            path: '/internal',
+            method: 'GET',
+            handler: function (request, reply) {
+                return reply(Boom.internal());
+            }
+        });
+
+        server.route({
+            path: '/',
+            method: 'GET',
+            handler: function (request, reply) {
+                return reply();
+            }
+        });
+
+        server.register({
+            register: plugin,
+            options : {
+                wrap: function (error, callback) {
+
+                    if (error instanceof ValidationError) {
+                        var wrapped = Boom.preconditionFailed(error.message);
+                        return callback(null, wrapped);
+                    }
+
+                    return callback(null, error);
+                },
+
+                track: config.airbrake
+            }
+        }, done);
+    });
+
+    lab.experiment('when there are errors', function () {
+
+        var mock;
+        var path = '/notifier_api/v2/notices';
+
+        var filter = function (hidden) {
+
+            return function (payload) {
+
+                var doc = libxmljs.parseXml(payload);
+
+                var environment = doc.get('//cgi-data');
+                var variables = environment.childNodes().map(function (node) {
+                    return node.attr('key').value();
+                });
+
+                Code.expect(variables).to.not.include(hidden);
+
+                return '*';
+            };
+        };
+
+        lab.experiment('for mongoose validation errors', function () {
+
+            lab.test('should return precondition failed error to the client but not track on airbrake server', function (done) {
+
+                server.inject('/validation', function (response) {
+
+                    Code.expect(response.statusCode).to.equal(412);
+                    return done();
+                });
+            });
+        });
+
+        lab.experiment('for expected application errors', function () {
+
+            lab.test('should return the specific error to the client but not track on airbrake server', function (done) {
+
+                server.inject('/native', function (response) {
+
+                    Code.expect(response.statusCode).to.equal(410);
+                    return done();
+                });
+            });
+        });
+
+        lab.experiment('for unexpected or internal server errors', function () {
+
+            lab.test('should return generic error to the client and track on airbrake server', function (done) {
+
+                mock = nock(config.airbrake.host)
+                    .filteringRequestBody(filter(config.airbrake.hidden))
+                    .post(path, '*')
+                    .reply(200);
+
+                server.inject('/internal', function (response) {
+
+                    Code.expect(response.statusCode).to.equal(500);
+                    mock.done();
+
+                    return done();
+                });
+            });
+        });
+    });
+
+    lab.experiment('when there are no errors', function () {
+
+        lab.test('should return control to the server', function (done) {
+
+            server.inject('/', function (response) {
+
+                Code.expect(response.statusCode).to.equal(200);
+
+                return done();
+            });
+        });
+    });
+});

--- a/test/include.js
+++ b/test/include.js
@@ -23,7 +23,7 @@ var plugin = require('../');
 
 var lab = exports.lab = Lab.script();
 
-lab.experiment('The server extension handles', function () {
+lab.experiment('The server extension, considering client issues', function () {
 
     var server, config;
 
@@ -33,7 +33,8 @@ lab.experiment('The server extension handles', function () {
             airbrake: {
                 host: 'http://airbrake.host.com',
                 key: 'airbrake_key',
-                hidden: ['VAR_1', 'VAR_2']
+                hidden: ['VAR_1', 'VAR_2'],
+                clientErrors: true
             }
         };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var Code = require('code');
+var libxmljs = require('libxmljs');
+
+exports.verify = function (expected) {
+
+    return function (payload) {
+
+        var doc = libxmljs.parseXml(payload);
+
+        var environment = doc.get('//cgi-data');
+        var variables = environment.childNodes().map(function (node) {
+            return node.attr('key').value();
+        });
+
+        Code.expect(variables).to.not.include(expected.hidden);
+
+        var endpoint = doc.get('request/url').text().toString();
+        Code.expect(endpoint).to.endWith(expected.endpoint);
+
+        var params = doc.get('//params');
+        params.childNodes().forEach(function (node) {
+
+            var attribute = node.attr('key').value();
+            Code.expect(attribute).to.equal('param');
+
+            var value = node.text();
+            Code.expect(value).to.equal('value');
+        });
+
+        return '*';
+    };
+};


### PR DESCRIPTION
This branch adds support for filtering client errors (4XX) and ensures additional request context like the `url` and `params` are attached to the airbrake message.
